### PR TITLE
add executor to the server makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,20 @@
+.PHONY: server client clean libs
+
 all: libs server client test
 
-CSVS := $(wildcard data/raw/*.csv)
-
-libs:
-	mkdir -p test/nlohmann
-	curl -sL https://raw.githubusercontent.com/nlohmann/json/develop/single_include/nlohmann/json.hpp -o ./test/nlohmann/json.hpp
-
-build/processor: process_data/process_data_main.cc
-	mkdir -p build
-	g++ -std=c++20 $^ -o $@
-
-# Don't add data to all as data is a PHONY target
-data: $(CSVS) build/processor
-	mkdir -p data/processed
-	@for file in $(CSVS); do \
-		./build/processor $$file; \
-	done
-
-server: build/server
-build/server:
+server:
 	cd src/server && make && cd ../..
 
-client: build/client
-build/client:
+client:
 	cd src/client && make && cd ../..
 
 test: 
 	echo "NOT IMPLEMENTED BECAUSE CENTRAL TEST MAKEFILE ISN'T IMPLEMENTED YET"
 
-.PHONY: clean
 clean:
 	rm -rf build
+
+# Add any external libraries here. Make sure you put the installation location in .gitignore, and update the README.
+libs:
+	mkdir -p ./test/nlohmann/
+	curl -sL https://raw.githubusercontent.com/nlohmann/json/develop/single_include/nlohmann/json.hpp -o ./test/nlohmann/json.hpp

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ data: $(CSVS) build/processor
 
 server: build/server
 build/server:
-	echo "THIS WONT COMPILE BECAUSE OF MISSING EXECUTOR.CC; TEST WITH A DUMMY FUNCTION INSTEAD \(You can use early return in line 82 of server\)"
 	cd src/server && make && cd ../..
 
 client: build/client

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,6 @@ clean:
 # Add any external libraries here. Make sure you put the installation location in .gitignore, and update the README.
 libs:
 	mkdir -p ./test/nlohmann/
-	curl -sL https://raw.githubusercontent.com/nlohmann/json/develop/single_include/nlohmann/json.hpp -o ./test/nlohmann/json.hpp
+	if [ ! -f ./test/nlohmann/json.hpp ]; then \
+		curl -sL https://raw.githubusercontent.com/nlohmann/json/develop/single_include/nlohmann/json.hpp -o ./test/nlohmann/json.hpp; \
+	fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Trading Query Project
 
+## Makefiles
+Each component has its own makefile and can be compiled by running `make` in the respective directory. To make the whole program, call `make` from the project root.
+
+### Extending the Makefiles
+If your making a new main process, make a seperate Makefile.
+If you're adding components to an executable, make a new rule for the component's object file and add it as a pre-req for the target executable. Make sure to add any required directories in the `make dirs` target.
+
+In general, just read the Makefile and you'll immediately know what to do.
+
 ## External Tools
 run `make libs` to install nlohmann (a test dependency)
 

--- a/src/client/Makefile
+++ b/src/client/Makefile
@@ -25,7 +25,3 @@ $(OBJ_DIR)/net/net.o: ../utils/net/net.cc
 .PHONY: clean
 clean:
 	rm -rf $(BUILD_DIR)
-
-.PHONY: remake
-remake:
-	make clean && make

--- a/src/server/Makefile
+++ b/src/server/Makefile
@@ -1,55 +1,37 @@
-# src/server/Makefile
-
-CXX := g++
-
-CXXFLAGS := -std=c++20 -Wall -Wextra -pedantic -fsanitize=address
-CXX_DEBUG_FLAGS   := -g3 -ggdb3
-CXX_RELEASE_FLAGS := -O3
-CXXFLAGS += $(CXX_DEBUG_FLAGS)
-
-LDFLAGS := -fsanitize=address
-LIBS := fmt spdlog
-LIB_FLAGS := $(addprefix -l,$(LIBS))
-LDFLAGS += $(LIB_FLAGS)
+STD_FLAG := -std=c++20
+LD_FLAGS := -lspdlog -lfmt
 BUILD_DIR := ../../build
-SRC_DIR   := ../../src
+OBJ_DIR := $(BUILD_DIR)/obj
 
-# find all server-related .cc under src, excluding client codeAdd commentMore actions
-SERVER_SRCS := $(shell find $(SRC_DIR) -type f -name '*.cc' -not -path '*/client/*' -not -name 'client_main.cc')
-SERVER_OBJS := $(patsubst $(SRC_DIR)/%.cc,$(BUILD_DIR)/%.o,$(SERVER_SRCS))
+all: dirs $(BUILD_DIR)/server
 
+dirs:
+	mkdir -p $(BUILD_DIR)
+	mkdir -p $(OBJ_DIR)/server
+	mkdir -p $(OBJ_DIR)/net
+	mkdir -p $(OBJ_DIR)/executor
 
-ALL_OBJS := $(sort $(SERVER_OBJS))
-DEPS := $(ALL_OBJS:.o=.d)
+$(BUILD_DIR)/server: $(OBJ_DIR)/server/server_main.o $(OBJ_DIR)/server/server.o $(OBJ_DIR)/net/net.o $(OBJ_DIR)/server/sender.o $(OBJ_DIR)/server/receiver.o $(OBJ_DIR)/executor/executor.o
+	g++ $(STD_FLAG) $(OBJ_DIR)/server/server_main.o $(OBJ_DIR)/server/server.o $(OBJ_DIR)/net/net.o $(OBJ_DIR)/server/sender.o $(OBJ_DIR)/server/receiver.o $(OBJ_DIR)/executor/executor.o -o $(BUILD_DIR)/server $(LD_FLAGS)
 
-INC_DIRS  := $(shell find $(SRC_DIR) -type d) \
-			 server \
-			 ../utils
-INC_FLAGS := $(addprefix -I,$(INC_DIRS))
+$(OBJ_DIR)/server/server_main.o: ../server_main.cc
+	g++ $(STD_FLAG) -c ../server_main.cc -o $(OBJ_DIR)/server/server_main.o
 
-CPPFLAGS := $(INC_FLAGS) -MMD -MP
+$(OBJ_DIR)/server/server.o: server.cc
+	g++ $(STD_FLAG) -c server.cc -o $(OBJ_DIR)/server/server.o
 
-.PHONY: all
-all: $(BUILD_DIR)/server-bin
+$(OBJ_DIR)/net/net.o: ../utils/net/net.cc
+	g++ $(STD_FLAG) -c ../utils/net/net.cc -o $(OBJ_DIR)/net/net.o
 
-$(BUILD_DIR)/server-bin: $(SERVER_OBJS)
-	$(CXX) $(CXXFLAGS) $^ -o $@ $(LDFLAGS)
+$(OBJ_DIR)/server/receiver.o: receiver.cc
+	g++ $(STD_FLAG) -c receiver.cc -o $(OBJ_DIR)/server/receiver.o
 
-# compile any .cc into build/%.o (preserving directory structure)Add commentMore actions
-$(BUILD_DIR)/%.o: $(SRC_DIR)/%.cc
-	mkdir -p $(dir $@)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+$(OBJ_DIR)/server/sender.o: sender.cc
+	g++ $(STD_FLAG) -c sender.cc -o $(OBJ_DIR)/server/sender.o
 
-.PHONY: print-vars
-print-vars:
-	@echo "SERVER_SRCS   = $(SERVER_SRCS)"
-	@echo "SERVER_OBJS   = $(SERVER_OBJS)"
-	@echo "ALL_OBJS      = $(ALL_OBJS)"
-	@echo "DEPS          = $(DEPS)"
-	@echo "INC_FLAGS     = $(INC_FLAGS)"
+$(OBJ_DIR)/executor/executor.o: ../executor/executor.cc
+	g++ $(STD_FLAG) -c ../executor/executor.cc -o $(OBJ_DIR)/executor/executor.o
 
 .PHONY: clean
 clean:
-	rm -rf build
-
--include $(DEPS)
+	rm -rf $(BUILD_DIR)

--- a/src/server/sender.cc
+++ b/src/server/sender.cc
@@ -1,4 +1,3 @@
-//
 #include "sender.h"
 
 #include "../utils/query.h"

--- a/src/server/sender.cc
+++ b/src/server/sender.cc
@@ -1,3 +1,4 @@
+//
 #include "sender.h"
 
 #include "../utils/query.h"


### PR DESCRIPTION
These changes were expected to be completed alongside pushing executor.cc (specific instructions were given, but they chose to revert to the old autofinder Makefile)

Anyway, doing it now since it hasn't already been done.
As the author, I have tested the compilation and running on my personal AWS instance.