### PR TITLE
Refactor variable names

### DIFF
--- a/process_data/make_page_table.cc
+++ b/process_data/make_page_table.cc
@@ -11,7 +11,8 @@
 
 int main(int argc, char** argv) {
     if (argc < 2) {
-        std::cerr << "Usage: " << argv[0] << " <number_of_trades>" << std::endl;
+        std::cerr << "Usage: " << argv[0] << " <file-name>" << std::endl;
+        std::cerr << "Example file names: example, tiny" << std::endl;
         return 1;
     }
     std::string file = argv[1];

--- a/process_data/make_page_table.cc
+++ b/process_data/make_page_table.cc
@@ -9,40 +9,39 @@
 #include "../src/query_engine/query_engine.h"
 #include "../src/query_engine/page_table.h"
 
-int main(int argc, char** argv) {
+int32_t main(int32_t argc, char** argv) {
     if (argc < 2) {
         std::cerr << "Usage: " << argv[0] << " <file-name>" << std::endl;
         std::cerr << "Example file names: example, tiny" << std::endl;
         return 1;
     }
-    std::string file = argv[1];
-    Query_engine query_engine(file);
-    std::ofstream out("data/processed/page-table-" + file + "-outer.bin", std::ios::binary);
+    std::string filename = argv[1];
+    Query_engine query_engine(filename);
+    std::ofstream outer_page_table_bin("data/processed/page-table-" + filename + "-outer.bin", std::ios::binary);
     
-    if (!out.is_open()) {
+    if (!outer_page_table_bin.is_open()) {
         std::cerr << "Error: could not open output file for writing." << std::endl;
         return 1;
     }
 
-    std::ofstream out2("data/processed/page-table-" + file + "-inner.bin", std::ios::binary);
+    std::ofstream inner_page_table_bin("data/processed/page-table-" + filename + "-inner.bin", std::ios::binary);
 
-    if (!out2.is_open()) {
+    if (!inner_page_table_bin.is_open()) {
         std::cerr << "Error: could not open inner output file for writing." << std::endl;
         return 1;
     }
 
     int64_t ind = 0;
     TradeData trade;
-    std::cout << sizeof(TradeData) << " bytes per trade" << std::endl;
     while (ind < query_engine.trades_size) {
         query_engine.read_trade_data(ind, trade);
-        out.write(reinterpret_cast<const char*>(&trade.created_at), sizeof(uint64_t));
+        outer_page_table_bin.write(reinterpret_cast<const char*>(&trade.created_at), sizeof(uint64_t));
         ind += (1 << 17);
         if (ind % (1 << 26) == 0) {
-            out2.write(reinterpret_cast<const char*>(&trade), sizeof(TradeData));
+            inner_page_table_bin.write(reinterpret_cast<const char*>(&trade), sizeof(TradeData));
         }
     }
-    out.close();
-    out2.close();
+    outer_page_table_bin.close();
+    inner_page_table_bin.close();
     std::cout << "Page table created successfully with " << ind / 128 << " pages." << std::endl;
 }


### PR DESCRIPTION
Changed variable names for lesser ambiguity while naming. Changed data type of `argc` and return value of main to be more specific.