### PR TITLE
Add outer and inner page tables

### DIFF
--- a/process_data/make_page_table.cc
+++ b/process_data/make_page_table.cc
@@ -36,12 +36,13 @@ int32_t main(int32_t argc, char** argv) {
     while (ind < query_engine.trades_size) {
         query_engine.read_trade_data(ind, trade);
         outer_page_table_bin.write(reinterpret_cast<const char*>(&trade.created_at), sizeof(uint64_t));
-        ind += (1 << 17);
         if (ind % (1 << 26) == 0) {
-            inner_page_table_bin.write(reinterpret_cast<const char*>(&trade), sizeof(TradeData));
+            inner_page_table_bin.write(reinterpret_cast<const char*>(&trade.created_at), sizeof(uint64_t));
         }
+        ind += (1 << 17);
     }
     outer_page_table_bin.close();
     inner_page_table_bin.close();
+
     std::cout << "Page table created successfully with " << ind / 128 << " pages." << std::endl;
 }

--- a/src/query_engine/query_engine.h
+++ b/src/query_engine/query_engine.h
@@ -18,7 +18,7 @@ class Query_engine {
 public:
     
   Query_engine(const std::string& file);
-  ~Query_engine() = default;
+  ~Query_engine();
   /**
     * @brief Computes the lowest and highest prices within the given query window.
     *
@@ -34,9 +34,21 @@ public:
     */
   std::vector<TradeData> send_raw_data(TradeDataQuery &query);
   uint64_t trades_size;
+  uint32_t outer_page_table_size;
+  uint32_t inner_page_table_size;
   bool read_trade_data(uint64_t ind, TradeData& trade);
 
+  /**
+    * @brief Retrieves outer page table data (trade.created_at) for a particular index
+    *
+    * @param index The index for which the outer page table data needs to be retrieved
+    * @return trade.created_at for the corresponding index 
+    */
+  uint64_t read_outer_page_table_data(uint64_t index);
+
 private:
+  uint64_t* outer_page_table;
+  uint64_t* inner_page_table;
   std::ifstream data;  // File stream for reading trade data
   // Any Internal members can be added here
   // std::vector<TradeData> trades;


### PR DESCRIPTION
Add the timestamps for inner and outer page tables. The page tables contain timestamps of specific data points which are to be used as reference when answering client queries