### PR TITLE
move page tables to server and allocate a page in query_engine

### DIFF
--- a/src/query_engine/page_table.h
+++ b/src/query_engine/page_table.h
@@ -1,8 +1,0 @@
-#pragma once
-#include <cstdint>
-
-#define PAGE_SIZE 4*1024*1024
-#define PAGE
-
-struct pgtable_t {
-};

--- a/src/query_engine/query_engine.h
+++ b/src/query_engine/query_engine.h
@@ -17,7 +17,7 @@
 class Query_engine {
 public:
     
-  Query_engine(const std::string& file);
+  Query_engine(const std::string& file, uint64_t* outer_page_table = nullptr, uint64_t* inner_page_table = nullptr);
   ~Query_engine();
   /**
     * @brief Computes the lowest and highest prices within the given query window.
@@ -34,8 +34,7 @@ public:
     */
   std::vector<TradeData> send_raw_data(TradeDataQuery &query);
   uint64_t trades_size;
-  uint32_t outer_page_table_size;
-  uint32_t inner_page_table_size;
+  
   bool read_trade_data(uint64_t ind, TradeData& trade);
 
   /**
@@ -47,7 +46,9 @@ public:
   uint64_t read_outer_page_table_data(uint64_t index);
 
 private:
-  uint64_t* outer_page_table;
+	int64_t open_page;
+	TradeData* page;
+	uint64_t* outer_page_table;
   uint64_t* inner_page_table;
   std::ifstream data;  // File stream for reading trade data
   // Any Internal members can be added here

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -36,10 +36,31 @@ EpollServer::EpollServer(uint16_t port, const std::string& file)
   make_non_blocking(server_listen_fd_);
   bind_server();
   add_to_epoll(server_listen_fd_);
+
+  std::ifstream outer_page_table_file("data/processed/page-table-" + file + "-outer.bin", std::ios::in | std::ios::binary);
+  std::ifstream inner_page_table_file("data/processed/page-table-" + file + "-inner.bin", std::ios::in | std::ios::binary);
+
+  outer_page_table_size = outer_page_table_file.seekg(0, std::ios::end).tellg() / sizeof(uint64_t);
+  outer_page_table_file.seekg(0, std::ios::beg);
+
+  outer_page_table = new uint64_t[outer_page_table_size];
+
+  inner_page_table_size = inner_page_table_file.seekg(0, std::ios::end).tellg() / sizeof(uint64_t);
+  inner_page_table_file.seekg(0, std::ios::beg);
+
+  inner_page_table = new uint64_t[inner_page_table_size];
+
+  outer_page_table_file.read(reinterpret_cast<char*>(outer_page_table), outer_page_table_size * sizeof(uint64_t));
+  inner_page_table_file.read(reinterpret_cast<char*>(inner_page_table), inner_page_table_size * sizeof(uint64_t));
+
+  outer_page_table_file.close();
+  inner_page_table_file.close();
 }
 
 EpollServer::~EpollServer()
 {
+  delete[] outer_page_table;
+  delete[] inner_page_table;
   close(server_listen_fd_);
   close(epoll_fd_);
   spdlog::info("Server ended");

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -28,7 +28,13 @@ private:
   int32_t server_listen_fd_;
   int32_t epoll_fd_;
 
-  std::mutex task_queue_mutex_;
+  uint64_t* outer_page_table;
+  uint64_t* inner_page_table;
+
+  uint32_t outer_page_table_size;
+  uint32_t inner_page_table_size;
+
+  // std::mutex task_queue_mutex_;
   // std::queue<TradeDataQuery> task_queue_;
   
   // std::mutex request_queue_mutex_;


### PR DESCRIPTION
Move the page tables to server and allocate a page in query_engine to manage the same page table in all query_engine threads and a page per query_engine class